### PR TITLE
Update implementation of NSData

### DIFF
--- a/Bridged/FileLoaders.h
+++ b/Bridged/FileLoaders.h
@@ -14,8 +14,8 @@ BOOL PFPropertyListWriteToURL(CFPropertyListRef item, CFURLRef url, BOOL atomica
 BOOL PFPropertyListWriteToPath(CFPropertyListRef list, CFStringRef path, BOOL atomically, CFErrorRef *error);
 
 // This version should be able to deal with data:// URLs and server URLs
-CFDataRef PFDataInitFromURL(CFURLRef url, NSDataReadingOptions options, CFErrorRef *error);
-CFDataRef PFDataInitFromPath(CFStringRef path, NSDataReadingOptions options, CFErrorRef *error);
+CFDataRef PFDataInitFromURL(CFURLRef url, NSDataReadingOptions options, BOOL mutable, CFErrorRef *error);
+CFDataRef PFDataInitFromPath(CFStringRef path, NSDataReadingOptions options, BOOL mutable, CFErrorRef *error);
 
 BOOL PFDataWriteToURL(CFDataRef data, CFURLRef url, NSDataWritingOptions options, CFErrorRef *error);
 BOOL PFDataWriteToPath(CFDataRef data, CFStringRef path, NSDataWritingOptions options, CFErrorRef *error);


### PR DESCRIPTION
Updates implementation of NSData:
* Changes behaviour of 'no copy' methods when creating mutable data to match documented behaviour
* Implements mapped data
